### PR TITLE
**Updated:** VSIX Manifest file to support Visual Studio 2019.

### DIFF
--- a/Xamaridea.VisualStudioPlugin/source.extension.vsixmanifest
+++ b/Xamaridea.VisualStudioPlugin/source.extension.vsixmanifest
@@ -12,13 +12,13 @@
     <Tags>Xamarin.Android, Android Studio, IDEA, AXML</Tags>
   </Metadata>
   <Installation InstalledByMsi="false">
-    <InstallationTarget Version="[12.0,16.0)" Id="Microsoft.VisualStudio.IntegratedShell" />
-    <InstallationTarget Version="[12.0,16.0)" Id="Microsoft.VisualStudio.Community" />
-    <InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.Pro" />
-    <InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.Enterprise" />
-    <InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.Premium" />
-    <InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.Ultimate" />
-    <InstallationTarget Version="[12.0,16.0)" Id="Microsoft.VisualStudio.VSLS" />
+    <InstallationTarget Version="[12.0,17.0)" Id="Microsoft.VisualStudio.IntegratedShell" />
+    <InstallationTarget Version="[12.0,17.0)" Id="Microsoft.VisualStudio.Community" />
+    <InstallationTarget Version="[11.0,17.0)" Id="Microsoft.VisualStudio.Pro" />
+    <InstallationTarget Version="[11.0,17.0)" Id="Microsoft.VisualStudio.Enterprise" />
+    <InstallationTarget Version="[11.0,17.0)" Id="Microsoft.VisualStudio.Premium" />
+    <InstallationTarget Version="[11.0,17.0)" Id="Microsoft.VisualStudio.Ultimate" />
+    <InstallationTarget Version="[12.0,17.0)" Id="Microsoft.VisualStudio.VSLS" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
@@ -28,6 +28,6 @@
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
   </Assets>
   <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[14.0,16.0)" DisplayName="Visual Studio core editor" />
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[14.0,17.0)" DisplayName="Visual Studio core editor" />
   </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
I've had a look into this one and I believe these changes should allow the Extension to work with Visual Studio 2019.

Original issue: [Issue #20 - Install on Visual Studio 2019 fails](https://github.com/EgorBo/Xamaridea/issues/20)

This involved some minor updates to the Manifest file to allow later Versions of Visual Studio and also updated the Version Range for the 'Microsoft.VisualStudio.Component.CoreEditor' prerequisite.

Hope this helps!